### PR TITLE
remove bad Mountebank link from docs

### DIFF
--- a/src/website/content/ecosystem/http4k/reference/core/index.md
+++ b/src/website/content/ecosystem/http4k/reference/core/index.md
@@ -264,8 +264,8 @@ client.received.take(2).forEach(::println)
 
 ### Request and Response toString()
 
-The HttpMessages used by http4k toString in the HTTP wire format, which it simple to capture and replay HTTP message
-streams later in a similar way to tools like [Mountebank](http://www.mbtest.org/).
+The HttpMessages used by http4k toString in the HTTP wire format, which makes it simple to capture and replay HTTP message
+streams later.
 
 ### CURL format
 


### PR DESCRIPTION
The Mountebank link currently present in the documentation (`mbtest.org`) appears to have been taken over by another entity completely unrelated to HTTP testing. I don't understand the language of the new site, but it appears to be advertising an online casino, maybe? It's very sketchy, whatever it is.

Mountebank itself has been marked as "no longer maintained" and there is an open issue on their side to remove all association from this domain as well: https://github.com/bbyars/mountebank/issues/783

Out of an abundance of caution, I intentionally did not link to the mbtest site directly but it did come back clear on VirusTotal (https://www.virustotal.com/gui/url/383bdd71c756f62ac8ba99a0f70badd24fa8eccfd9c7c84aa25a9f427444f042) . You can visit at your own risk if you wish to verify.

I would be happy to update this PR to include a link to an alternative, actively-maintained tool in place of the Mountebank link, but I will have to rely on your expertise for which tool(s) to suggest in its place. I'm not aware of any.

---

I also fixed a minor grammar error earlier in the sentence (word missing).