### PR TITLE
Capture more in GA4: 404s, on-site search, and code copies

### DIFF
--- a/src/website/layouts/404.html
+++ b/src/website/layouts/404.html
@@ -41,4 +41,21 @@
 
 <div style="padding-bottom: 80px;"></div>
 
+{{/* Report 404s to GA4 as a dedicated event so they can be isolated from real
+     pageviews, and capture the referrer to find where broken links originate. */}}
+<script>
+    (function () {
+        var attempted = window.location.pathname + window.location.search;
+        var referrer = document.referrer || "(none)";
+
+        if (typeof gtag === "function") {
+            gtag("event", "page_not_found", {
+                page_location: window.location.href,
+                page_path: attempted,
+                page_referrer: referrer,
+            });
+        }
+    })();
+</script>
+
 {{ end }}


### PR DESCRIPTION
Closes gaps in our GA4 coverage where high-signal interactions weren't being recorded. Three self-contained tracking additions, no console-side prerequisites.

## 1. 404s (`page_not_found`)

The `404.html` page had no analytics treatment, so broken-URL hits were recorded as ordinary pageviews — indistinguishable from real pages, and **with no referrer**, so there was no way to find where the broken links originate. Now fires a dedicated `page_not_found` event with the attempted path and referrer (`layouts/404.html`).

## 2. On-site search (`search`)

The custom Fuse.js Cmd+K overlay fired zero analytics, and GA4's built-in site-search measurement can't see it (the query never hits the URL). Now sends GA4's standard `search` event — debounced so it captures the settled query — with `search_term` and `result_count`. **Zero-result searches reveal what visitors expect but can't find** (`static/js/fuse-search.js`).

## 3. Code copies (`copy_code`)

Docs code blocks have a copy button but no tracking. Now fires `copy_code` (with `code_language` where available) on both copy buttons, showing which snippets actually get used (`static/js/footer.js`, `static/js/index.js`).

## Using these in GA4

- All three appear under *Reports → Engagement → Events*.
- Build Explorations on each: `page_not_found` × `page_referrer`, `search` filtered to `result_count = 0`, `copy_code` × `code_language`.
- To see custom params (`page_referrer`, `result_count`, `code_language`) as columns in standard reports, register them once as event-scoped custom dimensions (*Admin → Custom definitions*). They work in Explorations immediately.

### Not included (GA console settings — no code)
- Enable Enhanced Measurement (outbound clicks, scroll, file downloads) on the data stream.
- Mark the events above as Key Events to surface them as conversions.
- Consent Mode v2 (needs a consent banner — a larger change; happy to follow up).

https://claude.ai/code/session_017WkW1yrK4AWCwss52apur1